### PR TITLE
General Refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# VSCode user settings
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,3 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
-
-# VSCode user settings
-.vscode/

--- a/scripts/version_verification.py
+++ b/scripts/version_verification.py
@@ -4,7 +4,7 @@ from packaging.version import Version
 
 
 def verify_version_increased(last_version, current_version):
-    if not (last_version < current_version):
+    if current <= last:
         print('New version needs to be higher than old version')
         sys.exit(1)
     print('yes')
@@ -12,13 +12,13 @@ def verify_version_increased(last_version, current_version):
 
 
 def verify_version_equals(last_version, current_version):
-    if not (last_version == current_version):
+    if last_version != current_version:
         sys.exit(1)
     sys.exit(0)
 
 
 def verify_version_nequals(last_version, current_version):
-    if not (last_version == current_version):
+    if last_version != current_version:
         sys.exit(1)
     sys.exit(0)
 

--- a/scripts/version_verification.py
+++ b/scripts/version_verification.py
@@ -4,7 +4,7 @@ from packaging.version import Version
 
 
 def verify_version_increased(last_version, current_version):
-    if current <= last:
+    if current_version <= last_version:
         print('New version needs to be higher than old version')
         sys.exit(1)
     print('yes')

--- a/src/krait/cli.py
+++ b/src/krait/cli.py
@@ -54,8 +54,8 @@ help_link_objects = cast(
 
 help_links = {}
 
-for value in help_link_objects.values():
-    help_links.update(value.links)
+for obj in help_link_objects.values():
+    help_links.update(obj.links)
 
 
 canonical_name = {

--- a/src/krait/cli.py
+++ b/src/krait/cli.py
@@ -1,7 +1,17 @@
 # -*- coding: utf-8 -*-
+
+from typing import (
+    cast,
+    Type,
+    Dict,
+    List,
+    Union,
+    Optional,
+)
+from pathlib import Path
+
 import click
 import pydeepmerge as pdm  # type: ignore
-
 import krait.utils.plugins as plugin_utils
 import krait.utils.config as config_utils
 import krait.lib.plugins.project_frameworks as kproj
@@ -14,16 +24,6 @@ import krait.lib.renderers as rndr
 import krait.main as main
 
 import krait.utils.update as update_utils
-
-from typing import (
-    cast,
-    Type,
-    Dict,
-    List,
-    Union,
-    Optional,
-)
-from pathlib import Path
 
 
 project_frameworks = cast(
@@ -54,8 +54,8 @@ help_link_objects = cast(
 
 help_links = {}
 
-for obj in help_link_objects.values():
-    help_links.update(obj.links)
+for value in help_link_objects.values():
+    help_links.update(value.links)
 
 
 canonical_name = {

--- a/src/krait/lib/files.py
+++ b/src/krait/lib/files.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import krait.lib.abc as abc
-
 from typing import (
     Union,
     List,
@@ -8,6 +6,8 @@ from typing import (
     Optional,
 )
 from pathlib import Path
+
+import krait.lib.abc as abc
 from krait.utils.templates import env
 
 

--- a/src/krait/utils/config.py
+++ b/src/krait/utils/config.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
-import click
 import json
 from pathlib import Path
 from typing import (
     Dict,
     Any
 )
+import click
 
 
 def get_config_folder() -> Path:
-    dir = click.get_app_dir('Krait')
-    dir_path = Path(dir)
+    app_dir = click.get_app_dir('Krait')
+    dir_path = Path(app_dir)
     if not dir_path.exists():
         dir_path.mkdir()
 

--- a/src/krait/utils/templates.py
+++ b/src/krait/utils/templates.py
@@ -2,4 +2,4 @@
 import jinja2
 
 
-env = jinja2.Environment(loader=jinja2.PackageLoader('krait', 'templates'))
+env = jinja2.Environment(loader=jinja2.PackageLoader('krait', 'templates'), autoescape=False)

--- a/src/krait/utils/update.py
+++ b/src/krait/utils/update.py
@@ -69,14 +69,12 @@ def should_check_update(ctx: click.Context) -> bool:
 
 def run_python_command(cmd: str) -> str:
     try:
-        o = subprocess.check_output([
+        return subprocess.check_output([
             sys.executable,
             *cmd.split()
         ], stderr=subprocess.DEVNULL).decode('utf-8')
-    except Exception:
-        o = ''
-
-    return o
+    except subprocess.CalledProcessError:  # Non-zero exit code
+        return ''
 
 
 def run_pip(cmd: str) -> str:
@@ -116,12 +114,6 @@ def run_update():
     '''
     o = run_pip('show krait')
     if site.USER_SITE is not None and site.USER_SITE in o:
-        subprocess.call([
-            sys.executable,
-            *'-m pip install --user --upgrade krait'.split()
-        ])
+        run_pip('install --user --upgrade krait')
     else:
-        subprocess.call([
-            sys.executable,
-            *'-m pip install --upgrade krait'.split()
-        ])
+        run_pip('install --upgrade krait')

--- a/src/krait/utils/update.py
+++ b/src/krait/utils/update.py
@@ -70,12 +70,14 @@ def should_check_update(ctx: click.Context) -> bool:
 
 def run_python_command(cmd: str) -> str:
     try:
-        return subprocess.check_output([
+        o = subprocess.check_output([
             sys.executable,
             *cmd.split()
         ], stderr=subprocess.DEVNULL).decode('utf-8')
-    except subprocess.CalledProcessError:  # Non-zero exit code
-        return ''
+    except Exception:
+        o = ''
+
+    return o
 
 
 def run_pip(cmd: str) -> str:
@@ -115,6 +117,12 @@ def run_update():
     '''
     o = run_pip('show krait')
     if site.USER_SITE is not None and site.USER_SITE in o:
-        run_pip('install --user --upgrade krait')
+        subprocess.call([
+            sys.executable,
+            *'-m pip install --user --upgrade krait'.split()
+        ])
     else:
-        run_pip('install --upgrade krait')
+        subprocess.call([
+            sys.executable,
+            *'-m pip install --upgrade krait'.split()
+        ])

--- a/src/krait/utils/update.py
+++ b/src/krait/utils/update.py
@@ -2,12 +2,13 @@
 import subprocess
 import sys
 import os
-import click
 import site
 import re
 
 from datetime import datetime
 from pathlib import Path
+
+import click
 
 
 def get_update_file(ctx: click.Context) -> Path:


### PR DESCRIPTION
- Reorganized [import order](https://www.python.org/dev/peps/pep-0008/#:~:text=Imports%20should%20be%20grouped%20in%20the%20following%20order)
- Refactor on functions and variable names

[Note on autoescape](https://github.com/SeoFernando25/krait/blob/bc7a689158f44fd3d43f774c9bea3a3912f35b71/src/krait/utils/templates.py#L5): Something worth noting Jinja2 environment creation is that `autoescape` is set to `False` by default, would it do any harm in long term to turn it on to something like `autoescape=select_autoescape(['html', 'xml'])`?

