### PR TITLE
Add Makefile generation during project creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,5 +261,3 @@
 * Dev: setup of project repository. [Natalia Maximo]
 
 * Initial commit. [Natalia Maximo]
-
-

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: test
+test :
+	pytest
+
+.PHONY: check
+check :
+	mypy
+
+.PHONY: lint
+lint :
+	flake8

--- a/src/krait/lib/abc.py
+++ b/src/krait/lib/abc.py
@@ -74,6 +74,9 @@ class AbstractPlugin:
     def render_file(self):
         raise NotImplementedError()
 
+    def make_targets(self) -> Optional[str]:
+        raise NotImplementedError()
+
 
 class AbstractVCS(AbstractPlugin):
     def initialize(self, project_path: Path):

--- a/src/krait/lib/files.py
+++ b/src/krait/lib/files.py
@@ -91,3 +91,25 @@ class SetupConfig(File):
                 result.append(config)
 
         return '\n'.join(result)
+
+
+class MakeFile(File):
+    plugins: List[abc.AbstractPlugin]
+
+    def __init__(
+        self,
+        *plugins: abc.AbstractPlugin
+    ):
+        self.path = 'Makefile'
+        self.plugins = list(plugins)
+
+    @property
+    def contents(self) -> str:
+        result = []
+
+        for plugin in self.plugins:
+            targets = plugin.make_targets()
+            if targets:
+                result.append(targets)
+
+        return '\n\n'.join(result)

--- a/src/krait/lib/plugins/base_plugin.py
+++ b/src/krait/lib/plugins/base_plugin.py
@@ -73,7 +73,7 @@ class BasePythonPlugin(abc.AbstractPythonPlugin):
             return None
         if self._make_targets is not None:
             return self._make_targets
-        self._make_targets = '.PHONY: ' + ' '.join(self.phony_targets) + '\n'
+        self._make_targets = f'.PHONY: {" ".join(self.phony_targets)}\n'
         make_template = self.env.get_template(f'{self.make_name}-makefile.jinja2')
         self._make_targets += make_template.render(**self.make_vars) + '\n'
 

--- a/src/krait/lib/plugins/base_plugin.py
+++ b/src/krait/lib/plugins/base_plugin.py
@@ -23,6 +23,10 @@ class BasePythonPlugin(abc.AbstractPythonPlugin):
     setup_name: Optional[str]
     setup_vars: Dict[str, str]
     _setup_config: Optional[str]
+    phony_targets: List[str] = []
+    make_name: Optional[str] = None
+    make_vars: Dict[str, str] = {}
+    _make_targets: Optional[str] = None
     file_location: Optional[str]
     rendering_params: Dict[str, str]
 
@@ -63,3 +67,14 @@ class BasePythonPlugin(abc.AbstractPythonPlugin):
         self._setup_config = setup_template.render(**self.setup_vars) + '\n'
 
         return self._setup_config
+
+    def make_targets(self) -> Optional[str]:
+        if self.make_name is None:
+            return None
+        if self._make_targets is not None:
+            return self._make_targets
+        self._make_targets = '.PHONY: ' + ' '.join(self.phony_targets) + '\n'
+        make_template = self.env.get_template(f'{self.make_name}-makefile.jinja2')
+        self._make_targets += make_template.render(**self.make_vars) + '\n'
+
+        return self._make_targets

--- a/src/krait/lib/plugins/linters.py
+++ b/src/krait/lib/plugins/linters.py
@@ -14,6 +14,7 @@ from typing import (
 
 class BaseLinter(bp.BasePythonPlugin):
     configurations: Dict[str, str]
+    phony_targets = ['lint', 'fmt']
 
 
 class Flake8(BaseLinter):
@@ -27,6 +28,7 @@ class Flake8(BaseLinter):
     ):
         super().__init__(project_name, file_renderer, dir_renderer)
         self.setup_name = 'flake8'
+        self.make_name = 'flake8'
 
 
 class NoLinter(BaseLinter):

--- a/src/krait/lib/plugins/test_frameworks.py
+++ b/src/krait/lib/plugins/test_frameworks.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 class BaseTestFramework(bp.BasePythonPlugin):
     project_framework: pf.BaseProjectFramework
+    phony_targets = ['test']
 
     def __init__(
         self,
@@ -25,7 +26,6 @@ class BaseTestFramework(bp.BasePythonPlugin):
         file_renderer: rndr.FileRenderer,
         dir_renderer: rndr.DirectoryRenderer
     ):
-
         super().__init__(project_name, file_renderer, dir_renderer)
         self.project_framework = project_framework
         self.name = ''
@@ -50,6 +50,7 @@ class Pytest(BaseTestFramework):
         self.setup_vars = {'project_framework': project_framework.name}
         self.file_location = 'tests'
         self.file_name = project_framework.test_file
+        self.make_name = 'pytest'
 
 
 class NoTesting(BaseTestFramework):

--- a/src/krait/lib/plugins/type_checkers.py
+++ b/src/krait/lib/plugins/type_checkers.py
@@ -10,7 +10,7 @@ from typing import List
 
 
 class BaseTypeChecker(bp.BasePythonPlugin):
-    pass
+    phony_targets = ['check']
 
 
 class MyPy(BaseTypeChecker):
@@ -24,6 +24,7 @@ class MyPy(BaseTypeChecker):
     ):
         super().__init__(project_name, file_renderer, dir_renderer)
         self.setup_name = 'mypy'
+        self.make_name = 'mypy'
 
 
 class NoTypeChecker(BaseTypeChecker):

--- a/src/krait/main.py
+++ b/src/krait/main.py
@@ -49,10 +49,16 @@ def create(
         test_framework,
     )
     manifest_file = kf.File('MANIFEST.in', 'graft src')
+    makefile = kf.MakeFile(
+        linter,
+        type_checker,
+        test_framework,
+    )
 
     files.add_file(readme_file)
     files.add_file(setup_script)
     files.add_file(setup_config)
+    files.add_file(makefile)
     files.add_file(manifest_file)
     directories.create_all()
     files.write_all()

--- a/src/krait/templates/flake8-makefile.jinja2
+++ b/src/krait/templates/flake8-makefile.jinja2
@@ -1,0 +1,2 @@
+lint :
+	flake8

--- a/src/krait/templates/mypy-makefile.jinja2
+++ b/src/krait/templates/mypy-makefile.jinja2
@@ -1,0 +1,2 @@
+check :
+	mypy

--- a/src/krait/templates/pytest-makefile.jinja2
+++ b/src/krait/templates/pytest-makefile.jinja2
@@ -1,0 +1,2 @@
+test :
+	pytest


### PR DESCRIPTION
When creating a project, generate a Makefile with targets for the
- linter/formatter
- type checker
- test framework
so that the user can use the same commands uniformly across frameworks.

For example, a user wouldn't need to know if a krait-generated
project used `unittest`, `pytest`, `nose`, etc. -- the user need only
type `make test` at the command prompt and the generated target will
perform the appropriate action.

Note that the user will have to upgrade with `krait upgrade`
for the required template files to be copied;
`pip install -U krait` won't work.
