### PR TITLE
fix: fixed krait update checker to now use the Github API

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,13 +25,6 @@ jobs:
       contents: read
       security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'python' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
-
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -40,7 +33,7 @@ jobs:
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
-        languages: ${{ matrix.language }}
+        languages: python
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,13 +12,9 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
   schedule:
     - cron: '40 3 * * 0'
+  workflow_call:
 
 jobs:
   analyze:

--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -39,8 +39,12 @@ jobs:
         id: verify
         run: echo "::set-output name=run_deploy::$(python scripts/version_verification.py $(python scripts/extract_version.py) $(cat VERSION))"
 
+  code_analysis:
+    needs: [build-ubuntu, build-macos, build-windows]
+    uses: ./.github/workflows/codeql-analysis.yml
+
   release:
-    needs: version-check
+    needs: [version-check, code_analysis]
     runs-on: ubuntu-latest
     environment:
       name: deployment

--- a/src/krait/utils/update.py
+++ b/src/krait/utils/update.py
@@ -99,7 +99,7 @@ def check_for_update() -> str:
 
         json_data = json.loads(api_data)
         tag_version = json_data['tag_name']
-        o = run_pip('show krait | grep Version')
+        o = run_pip('show krait')
 
         if tag_version in o:
             return ''

--- a/src/krait/utils/update.py
+++ b/src/krait/utils/update.py
@@ -3,8 +3,9 @@ import subprocess
 import sys
 import os
 import site
-import re
+import json
 
+from urllib import request
 from datetime import datetime
 from pathlib import Path
 
@@ -86,21 +87,24 @@ def run_pip(cmd: str) -> str:
 
 def check_for_update() -> str:
     '''
-    Runs a pip search command for the krait package and checks to see
-    if the 'LATEST' tag is there. Should only affect packages with version
-    smaller than most recently released.
+    Queries the Github releases API to get the latest Krait release.
+
+    If a newer release exists, return the version. Otherwise, return
+    the empty string
     '''
     try:
-        o = run_pip('--timeout 3 --retries 0 search krait')
+        api_data = request.urlopen(
+            'https://api.github.com/repos/taliamax/krait/releases/latest'
+        ).read()
 
-        pattern = r'LATEST:\s+(\d+\.\d+(\.\d+)?)'
-        installed_pattern = r'INSTALLED:\s+(\d+\.\d+(\.\d+)?)'
-        m = re.search(pattern, o)
-        installed = re.search(installed_pattern, o)
-        if m and installed:
-            if installed.group(1) == m.group(1):
-                return ''
-            return m.group(1)
+        json_data = json.loads(api_data)
+        tag_version = json_data['tag_name']
+        o = run_pip('show krait | grep Version')
+
+        if tag_version in o:
+            return ''
+        return tag_version
+
     except Exception:
         pass
     return ''


### PR DESCRIPTION
Closes #9 

Fixed the problem by using the Github API instead of using `pip search`. Now it queries this repository for the latest release instead, which is simpler logic anyways since it doesn't rely on doing regexes on the output of a command. It does however still check the output of a command- will eventually use import lib or something similar to get a better version